### PR TITLE
`Promise#timeout`: clear the timeout once the promise is resolved/rejected.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -289,12 +289,19 @@ module.exports = function(Promise) {
   };
   TimeoutError.prototype = Object.create(Error.prototype);
 
+  var makeRejector = function(reject, message, ms) {
+    // create this function in an outer scope so that we don't inadvertently
+    // keep a reference to the promise here.  Perhaps this is overkill.
+    var id = setTimeout(function() { reject(new TimeoutError(message)); }, ms);
+    return function() { clearTimeout(id); };
+  };
   Promise.prototype.timeout = function(ms, message) {
     var P = this.constructor || Promise;
     var promise = this;
     return new P(function(resolve, reject) {
       promise.then(resolve, reject);
-      setTimeout(function() { reject(new TimeoutError(message)); }, ms);
+      var cleanup = makeRejector(reject, message, ms);
+      promise.then(cleanup, cleanup);
     });
   };
 


### PR DESCRIPTION
This keeps us from holding on to the `Promise` for the full timeout period.

Closes: #3
